### PR TITLE
fix: enable all necessary APIs without showing errors

### DIFF
--- a/examples/launchmybakery/setup/setup_env.sh
+++ b/examples/launchmybakery/setup/setup_env.sh
@@ -17,10 +17,10 @@ gcloud services enable aiplatform.googleapis.com --project=$PROJECT_ID
 gcloud services enable apikeys.googleapis.com --project=$PROJECT_ID
 gcloud services enable mapstools.googleapis.com --project=$PROJECT_ID
 ENABLED_SERVICES=$(gcloud beta services mcp list --enabled --format="value(name.basename())" --project=$PROJECT_ID)
-if [[ "$ENABLED_SERVICES" == *"mapstools.googleapis.com"* ]]; then
+if [[ ! "$ENABLED_SERVICES" == *"mapstools.googleapis.com"* ]]; then
     gcloud beta services mcp enable mapstools.googleapis.com --project=$PROJECT_ID
 fi
-if [[ "$ENABLED_SERVICES" == *"bigquery.googleapis.com"* ]]; then
+if [[ ! "$ENABLED_SERVICES" == *"bigquery.googleapis.com"* ]]; then
     gcloud beta services mcp enable bigquery.googleapis.com --project=$PROJECT_ID
 fi
 


### PR DESCRIPTION
enables aiplatform.googleapis.com to work with Vertex AI. hides error when trying to enable already enabled MCP. removes 'beta' command use for enabling mapstools.com service.