### PR TITLE
Add Chrome DevTools MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can run these open-source MCP servers locally, or deploy them to Google Clou
 * [**Google Cloud Observability**](https://github.com/googleapis/gcloud-mcp/tree/main/packages/observability-mcp)
 * [**Flutter/Dart**](https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp_server)
 * [**Google Maps Platform Code Assist toolkit**](https://developers.google.com/maps/ai/mcp)
+* [**Chrome DevTools**](https://github.com/ChromeDevTools/chrome-devtools-mcp)
 
 ## 💻 Examples
 


### PR DESCRIPTION
The Chrome DevTools MCP server is also an officially maintained MCP server.

More info at https://github.com/ChromeDevTools/chrome-devtools-mcp.