### PR TITLE
Fix: Add dotenv.load_dotenv() to tools.py

### DIFF
--- a/examples/launchmybakery/adk_agent/mcp_bakery_app/tools.py
+++ b/examples/launchmybakery/adk_agent/mcp_bakery_app/tools.py
@@ -4,16 +4,18 @@ import google.auth
 from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset
 from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams 
 
-MAPS_API_KEY = os.getenv('MAPS_API_KEY', 'no_api_found')
 MAPS_MCP_URL = "https://mapstools.googleapis.com/mcp" 
 BIGQUERY_MCP_URL = "https://bigquery.googleapis.com/mcp" 
 
 def get_maps_mcp_toolset():
+    dotenv.load_dotenv()
+    maps_api_key = os.getenv('MAPS_API_KEY', 'no_api_found')
+    
     tools = MCPToolset(
         connection_params=StreamableHTTPConnectionParams(
             url=MAPS_MCP_URL,
             headers={    
-                "X-Goog-Api-Key": MAPS_API_KEY
+                "X-Goog-Api-Key": maps_api_key
             }
         )
     )


### PR DESCRIPTION
Fixes #11

**Problem:**
The `tools.py` module was reading the `MAPS_API_KEY` environment variable before the `.env` file was loaded, causing it to always default to `'no_api_found'`.

**Root Cause:**
`MAPS_API_KEY` was being read at module import time, before any code called `dotenv.load_dotenv()`.

**Solution:**
Moved `dotenv.load_dotenv()` and API key retrieval inside the `get_maps_mcp_toolset()` function. This ensures the .env file is loaded before reading the environment variable.

**Why this approach:**
- ✅ Follows Python best practices (imports at top)
- ✅ Uses lazy evaluation for environment variables
- ✅ Avoids code execution at module import time
- ✅ Clean, minimal change

**Testing:**
Verified with dummy .env file that `MAPS_API_KEY` now correctly loads from the environment.

**Files Changed:**
- `examples/launchmybakery/adk_agent/mcp_bakery_app/tools.py`