### PR TITLE
fix(launchmybakery): fix Google Cloud MCP cold starts with explicit timeouts

### DIFF
--- a/examples/launchmybakery/adk_agent/mcp_bakery_app/tools.py
+++ b/examples/launchmybakery/adk_agent/mcp_bakery_app/tools.py
@@ -16,7 +16,9 @@ def get_maps_mcp_toolset():
             url=MAPS_MCP_URL,
             headers={    
                 "X-Goog-Api-Key": maps_api_key
-            }
+            },
+            timeout=30.0,          
+            sse_read_timeout=300.0
         )
     )
     print("MCP Toolset configured for Streamable HTTP connection.")
@@ -40,7 +42,9 @@ def get_bigquery_mcp_toolset():
     tools = MCPToolset(
         connection_params=StreamableHTTPConnectionParams(
             url=BIGQUERY_MCP_URL,
-            headers=HEADERS_WITH_OAUTH
+            headers=HEADERS_WITH_OAUTH,
+            timeout=30.0,          
+            sse_read_timeout=300.0
         )
     )
     print("MCP Toolset configured for Streamable HTTP connection.")


### PR DESCRIPTION
- Added `timeout` and `sse_read_timeout` to StreamableHTTPConnectionParams for both Maps and BigQuery toolsets.
- This prevents the underlying mcp-python-sdk from dropping the connection during an initial Google Cloud MCP server cold start.
- Fixes the `anyio.WouldBlock` exception that occurs when the server takes longer than the default 5 seconds to wake up and return the tools/list.