### PR TITLE
Add Angular CLI MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ You can run these open-source MCP servers locally, or deploy them to Google Clou
 * [**gcloud CLI**](https://github.com/googleapis/gcloud-mcp/tree/main/packages/gcloud-mcp)  
 * [**Google Cloud Observability**](https://github.com/googleapis/gcloud-mcp/tree/main/packages/observability-mcp)
 * [**Flutter/Dart**](https://github.com/dart-lang/ai/tree/main/pkgs/dart_mcp_server)
+* [**Angular**](https://github.com/angular/angular-cli/tree/main/packages/angular/cli/src/commands/mcp)
 * [**Google Maps Platform Code Assist toolkit**](https://developers.google.com/maps/ai/mcp)
 * [**Chrome DevTools**](https://github.com/ChromeDevTools/chrome-devtools-mcp)
 


### PR DESCRIPTION
Added the Angular MCP server to the open-source list. The entry href points to the Angular CLI repository.

Note: The official Angular CLI MCP docs are available at https://angular.dev/ai/mcp, in case the list is refactored in the future to a table showing the corresponding MCP documentation.