### PR TITLE
Fail fast when gcloud setup commands error (#15)

### DIFF
--- a/examples/launchmybakery/setup/setup_env.sh
+++ b/examples/launchmybakery/setup/setup_env.sh
@@ -13,16 +13,27 @@ echo "Found Project ID: $PROJECT_ID"
 
 # Enable necessary APIs
 echo "Enabling APIs.."
-gcloud services enable aiplatform.googleapis.com --project=$PROJECT_ID
-gcloud services enable apikeys.googleapis.com --project=$PROJECT_ID
-gcloud services enable mapstools.googleapis.com --project=$PROJECT_ID
-gcloud services enable bigquery.googleapis.com --project=$PROJECT_ID
+for SERVICE in aiplatform.googleapis.com apikeys.googleapis.com mapstools.googleapis.com bigquery.googleapis.com; do
+    if ! gcloud services enable "$SERVICE" --project=$PROJECT_ID; then
+        echo "Error: Failed to enable $SERVICE."
+        echo "Make sure you have the 'roles/serviceusage.serviceUsageAdmin' role."
+        exit 1
+    fi
+done
+
+# Enable MCP services
 ENABLED_SERVICES=$(gcloud beta services mcp list --enabled --format="value(name.basename())" --project=$PROJECT_ID)
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to list enabled MCP services."
+    exit 1
+fi
 if [[ ! "$ENABLED_SERVICES" == *"mapstools.googleapis.com"* ]]; then
-    gcloud --quiet beta services mcp enable mapstools.googleapis.com --project=$PROJECT_ID
+    gcloud --quiet beta services mcp enable mapstools.googleapis.com --project=$PROJECT_ID \
+        || { echo "Error: Failed to enable the mapstools MCP service."; exit 1; }
 fi
 if [[ ! "$ENABLED_SERVICES" == *"bigquery.googleapis.com"* ]]; then
-    gcloud --quiet beta services mcp enable bigquery.googleapis.com --project=$PROJECT_ID
+    gcloud --quiet beta services mcp enable bigquery.googleapis.com --project=$PROJECT_ID \
+        || { echo "Error: Failed to enable the bigquery MCP service."; exit 1; }
 fi
 
 # Create API Key
@@ -37,10 +48,12 @@ if [ $? -eq 0 ]; then
     API_KEY=$(echo "$API_KEY_JSON" | grep -oP '"keyString": "\K[^"]+' 2>/dev/null || echo "$API_KEY_JSON" | grep '"keyString":' | cut -d '"' -f 4)
     if [ -z "$API_KEY" ]; then
         echo "Could not parse API Key from JSON."
+    else
+        echo "Successfully created API Key."
     fi
-    echo "Successfully created API Key."
 else
     echo "Could not automate API key creation."
+    echo "(This usually means you are missing the 'roles/serviceusage.apiKeysAdmin' role.)"
     read -p "Please enter your Google Maps Platform API Key manually: " API_KEY
 fi
 

--- a/examples/petpassport/setup/setup_env.sh
+++ b/examples/petpassport/setup/setup_env.sh
@@ -13,14 +13,20 @@ echo "Found Project ID: $PROJECT_ID"
 
 # Enable necessary APIs
 echo "Enabling APIs..."
-gcloud services enable bigquery.googleapis.com --project=$PROJECT_ID
-gcloud services enable mapstools.googleapis.com --project=$PROJECT_ID
-gcloud services enable apikeys.googleapis.com --project=$PROJECT_ID
+for SERVICE in bigquery.googleapis.com mapstools.googleapis.com apikeys.googleapis.com; do
+    if ! gcloud services enable "$SERVICE" --project=$PROJECT_ID; then
+        echo "Error: Failed to enable $SERVICE."
+        echo "Make sure you have the 'roles/serviceusage.serviceUsageAdmin' role."
+        exit 1
+    fi
+done
 
 # Enable MCP services
 echo "Enabling MCP services..."
-gcloud --quiet beta services mcp enable bigquery.googleapis.com --project=$PROJECT_ID
-gcloud --quiet beta services mcp enable mapstools.googleapis.com --project=$PROJECT_ID
+gcloud --quiet beta services mcp enable bigquery.googleapis.com --project=$PROJECT_ID \
+    || { echo "Error: Failed to enable the bigquery MCP service."; exit 1; }
+gcloud --quiet beta services mcp enable mapstools.googleapis.com --project=$PROJECT_ID \
+    || { echo "Error: Failed to enable the mapstools MCP service."; exit 1; }
 
 # Prompt for API Key
 echo "----------------------------------------------------------------"


### PR DESCRIPTION
Closes #15.

The `setup/setup_env.sh` scripts called `gcloud services enable`, the MCP enable commands, and the API key creation without checking exit status. On an account with restricted IAM (e.g. missing `roles/serviceusage.serviceUsageAdmin` or `roles/serviceusage.apiKeysAdmin`) the commands fail but the script keeps going and writes a `.env` with an empty/invalid `MAPS_API_KEY`. Setup looks successful, then `adk web` fails later with a confusing error.

### Changes
- Check every `gcloud services enable` call; exit with a clear message and the IAM role likely needed.
- Check the `gcloud beta services mcp list` / `enable` calls instead of ignoring failures.
- Stop printing "Successfully created API Key" when the key couldn't be parsed, and hint at the missing role on the manual-entry fallback.
- Applied the same hardening to the petpassport setup script, which had the same pattern.

The existing empty-key guard before writing `.env` is kept as a final safety net.

Both scripts pass `bash -n`.